### PR TITLE
Make choices support `array` as value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
-# 0.2.2
+# 0.3.0
 
 * Bug Fixes
   * Allow `optional` and `recommended` to be passed in for `required` attribute rule. Fixes #1
+
+* Enhancements
+  * Validation of choices can now validate a value that is an array. For example an array of Postgres extensions inputted by a user against a master list
 
 # 0.2.1
 

--- a/README.md
+++ b/README.md
@@ -24,15 +24,17 @@ depends "validation"
 
 grouping "my_app",
   title: "My Application"
+
 attribute "my_app/log_level",
   required: "required",
   default: "debug",
-  choices: [
+  choice: [
     "debug",
     "fatal",
     "warn",
     "info"
   ]
+
 attribute "my_app/cookie",
   required: "required",
   default: "",
@@ -40,6 +42,23 @@ attribute "my_app/cookie",
 ```
 
 Attribute rules are already part of Chef metadata. However, they are not used at all by the Chef client application itself. You'll need to ensure that you still initialize attributes to their supposedly default value in an attributes file or a recipe.
+
+Allowed types:
+ * string
+ * hash
+ * array
+ * numeric (Fixnum)
+ * boolean (TrueClass, FalseClass)
+ * symbol
+
+Choice(s)
+
+There are two different fields for defining choices, `choice` and `choices`. As the name suggest
+the former (`choice`) is for when only one value can match and can work with any of the `type` and
+`choices` is meant for when you want to define multiple choices, such as when you want the user to
+enable/disable multiple postgresql extensions from an available list of items. This only works with `type` of `array`
+
+
 
 Since Chef client doesn't do anything with these attribute definitions we need to leverage the `validate_attributes` definition provided by this cookbook. Place a line like this in one of your cookbook's recipes.
 

--- a/lib/chef/validation/validator.rb
+++ b/lib/chef/validation/validator.rb
@@ -51,6 +51,9 @@ module Chef::Validation
         if rules["choice"].present?
           errors += validate_choice(value, rules["choice"], name)
         end
+        if rules["choices"].present?
+          errors += validate_choice(value, rules["choices"], name)
+        end
 
         errors
       end

--- a/lib/chef/validation/validator.rb
+++ b/lib/chef/validation/validator.rb
@@ -78,8 +78,14 @@ module Chef::Validation
 
         def validate_choice(value, choices, name)
           errors = []
-          unless choices.include?(value)
-            errors << "Must be one of the following choices: #{choices.join(", ")}."
+          if value.is_a?(Array)
+            unless value.select { |v| !choices.include?(v) }.empty?
+              errors << "Must be any of the following choices: #{choices.join(", ")}."
+            end
+          else
+            unless choices.include?(value)
+              errors << "Must be one of the following choices: #{choices.join(", ")}."
+            end
           end
           errors
         end

--- a/lib/chef/validation/version.rb
+++ b/lib/chef/validation/version.rb
@@ -1,4 +1,4 @@
 class Chef; end;
 module Chef::Validation
-  VERSION = "0.2.1"
+  VERSION = "0.3.0"
 end


### PR DESCRIPTION
A use case here would be to have 20 supported postgres extensions as the choices and the user may pass in 10
