### PR TITLE
When an attribute is optional but is not present (nil) then the code is still raising a type error check

### DIFF
--- a/lib/chef/validation/validator.rb
+++ b/lib/chef/validation/validator.rb
@@ -42,12 +42,25 @@ module Chef::Validation
             return errors
           end
         end
+
         if rules["required"].present?
           errors += validate_required(rules["required"], value)
+          # Bail out early
+          unless errors.empty?
+            return errors
+          end
         end
+
+        # Doing type / choice checks on optiona values when they are not present is no good
+        if (!rules["required"].present? or
+            ['optional', 'recommended', FalseClass].include?(rules["required"])) and value.nil?
+          return errors
+        end
+
         if rules["type"].present?
           errors += validate_type(value, rules["type"], name)
         end
+
         if rules["choice"].present?
           errors += validate_choice(value, rules["choice"], name)
         end


### PR DESCRIPTION
Additional enhancements to the previous PR that let optional / recommended required checks to be done.

If you specify an attribute rule with a specific type but also say it is optional then the type check would fail when the value isn't there because `dig` would come up with `nil` value for it when looking.
