### PR TITLE
Have `dig` support traversing through an array if given the right path to work from

### DIFF
--- a/lib/chef/validation/ext/hash.rb
+++ b/lib/chef/validation/ext/hash.rb
@@ -22,11 +22,16 @@ module Chef::Validation
       # @return [Object, nil]
       def dig(hash, path, separator = "/")
         return nil unless !path.nil? && !path.empty?
-        return nil unless hash.respond_to?(:has_key?)
-        return hash unless hash.respond_to?(:[])
 
         key, rest = path.split(separator, 2)
-        match     = hash[key.to_s].nil? ? hash[key.to_sym] : hash[key.to_s]
+        if hash.is_a?(Hash)
+          return nil unless hash.respond_to?(:has_key?)
+          return hash unless hash.respond_to?(:[])
+          match = hash[key.to_s].nil? ? hash[key.to_sym] : hash[key.to_s]
+        elsif hash.is_a?(Array)
+          match = hash[key.to_i]
+        end
+
         if rest.nil? or match.nil?
           match
         else

--- a/lib/chef/validation/ext/hash.rb
+++ b/lib/chef/validation/ext/hash.rb
@@ -25,8 +25,6 @@ module Chef::Validation
 
         key, rest = path.split(separator, 2)
         if hash.is_a?(Hash)
-          return nil unless hash.respond_to?(:has_key?)
-          return hash unless hash.respond_to?(:[])
           match = hash[key.to_s].nil? ? hash[key.to_sym] : hash[key.to_s]
         elsif hash.is_a?(Array)
           match = hash[key.to_i]


### PR DESCRIPTION
I came across a few internal (and in test-kitchen) usages of arrays instead of hashes and `dig` was choking on that.

a simple structure

```
{
      'volumes' => [
        {
          'user' => 'ubuntu',
          'device' => '/dev/sdm',
          'mount' => '/data'
        },
        {
          'mode' => '777',
          'device' => '/dev/sdo',
          'mount' => '/db'
        }
      ]
}
```

`dig('volumes/1/device')` should work but doesn't since `volumes` is an array

I honestly am not happy with the code but I didn't want to screw things up too much given the lack of tests
