### PR TITLE
Add rspec and chefspec tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+---
+sudo: false
+
+git:
+  depth: 5
+
+rvm:
+  - 2.0.0
+  - 2.1
+  - 2.2
+
+cache: bundler
+bundler_args: --jobs 7
+
+script: bundle exec rake

--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,11 @@
-require "bundler/gem_tasks"
+require 'bundler/gem_tasks'
+
+require 'rspec/core/rake_task'
+RSpec::Core::RakeTask.new do |t|
+  t.rspec_opts = [
+    '--color',
+    '--format progress',
+  ].join(' ')
+end
+
+task default: :spec

--- a/chef-validation.gemspec
+++ b/chef-validation.gemspec
@@ -21,5 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "chef", ">= 11.0.0"
 
   spec.add_development_dependency "bundler", "~> 1.7"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake"
+
+  spec.add_development_dependency 'chefspec', '~> 4.2'
 end

--- a/lib/chef/validation.rb
+++ b/lib/chef/validation.rb
@@ -50,7 +50,7 @@ module Chef::Validation
         total_errors = {}
         ContextExt.cookbooks(node.run_context).each do |cookbook|
           reload_metadata(cookbook)
-          unless (errors = Validator.run(node, cookbook.metadata)).empty?
+          unless (errors = Validator.run(node.attributes, cookbook.metadata.attributes, node.to_hash['recipe'])).empty?
             total_errors[cookbook.name] = errors
           end
         end
@@ -63,7 +63,7 @@ module Chef::Validation
           raise "Cookbook not found: #{cookbook}"
         end
         reload_metadata(cookbook)
-        unless (errors = Validator.run(node, cookbook.metadata)).empty?
+        unless (errors = Validator.run(node.attributes, cookbook.metadata.attributes, node.to_hash['recipe'])).empty?
           total_errors[cookbook.name] = errors
         end
         total_errors

--- a/lib/chef/validation/ext/hash.rb
+++ b/lib/chef/validation/ext/hash.rb
@@ -15,6 +15,21 @@ module Chef::Validation
       #
       #   HashExt.dig(hash, "deep/nested/hash") => :my_value
       #
+      # Accessing array elements by the integer key
+      #
+      # @example
+      #   nested_hash = {
+      #     "deep" => [
+      #       {
+      #         "nested" => {
+      #           "hash" => :my_value
+      #         }
+      #       }
+      #     ]
+      #   }
+      #
+      #   HashExt.dig(hash, "deep/1/nested/hash") => :my_value
+      #
       # @param [Hash] hash
       # @param [String] path
       # @param [String] separator
@@ -22,11 +37,14 @@ module Chef::Validation
       # @return [Object, nil]
       def dig(hash, path, separator = "/")
         return nil unless !path.nil? && !path.empty?
-        return nil unless hash.respond_to?(:has_key?)
-        return hash unless hash.respond_to?(:[])
 
         key, rest = path.split(separator, 2)
-        match     = hash[key.to_s].nil? ? hash[key.to_sym] : hash[key.to_s]
+        if hash.is_a?(Hash)
+          match = hash[key.to_s].nil? ? hash[key.to_sym] : hash[key.to_s]
+        elsif hash.is_a?(Array)
+          match = hash[key.to_i]
+        end
+
         if rest.nil? or match.nil?
           match
         else

--- a/lib/chef/validation/validator.rb
+++ b/lib/chef/validation/validator.rb
@@ -2,20 +2,21 @@ module Chef::Validation
   module Validator
     class << self
       # Validates that the given node object satisfies all of the attribute constraints
-      # found in the given metadata.
+      # found in the given metadata attributes.
       #
       # Returns a hash containing key/value pairs where the keys are the name of an
       # attribute which was not properly set on the node object and the values are
       # errors that were generated for that attribute.
       #
-      # @param [Chef::Node] node
-      # @param [Chef::Metadata] metadata
+      # @param [Hash]  node
+      # @param [Hash]  attributes
+      # @param [Array] recipes
       #
       # @return [Hash]
-      def run(node, metadata)
+      def run(node, attributes, recipes = {})
         errors = {}
-        metadata.attributes.each do |attribute, rules|
-          unless (err = validate(node, attribute, rules)).empty?
+        attributes.each do |attribute, rules|
+          unless (err = validate(node, attribute, rules, recipes)).empty?
             errors[attribute] = err
           end
         end
@@ -25,29 +26,44 @@ module Chef::Validation
       # Validates that the given node object passes the given validation rules for
       # the given attribute name.
       #
-      # @param [Chef::Node] node
-      #   node to validate
+      # @param [Hash] node
+      #   node attributes to validate
       # @param [String] name
       #   name of the attribute to validate
       # @param [Hash] rules
       #   a hash of rules (defined by the metadata of a cookbook)
+      # @param [Array] recipes
+      #   recipes to validate against
       #
       # @return [Array<String>]
-      def validate(node, name, rules)
-        value  = HashExt.dig(node.attributes, name, ATTR_SEPARATOR)
+      def validate(node, name, rules, recipes = {})
+        value  = HashExt.dig(node, name, ATTR_SEPARATOR)
         errors = []
 
         if rules["recipes"].present?
-          if rules["recipes"].select { |recipe| recipe_present?(node, recipe) }.empty?
+          if rules["recipes"].select { |recipe| recipe_present?(recipes, recipe) }.empty?
             return errors
           end
         end
+
         if rules["required"].present?
-          errors += validate_required(rules["required"], value)
+          errors += validate_required(rules["required"], value, name)
+          # Bail out early
+          unless errors.empty?
+            return errors
+          end
         end
+
+        # Doing type / choice checks on optiona values when they are not present is no good
+        if (!rules["required"].present? or
+            ['optional', 'recommended', FalseClass].include?(rules["required"])) and value.nil?
+          return errors
+        end
+
         if rules["type"].present?
           errors += validate_type(value, rules["type"], name)
         end
+
         if rules["choice"].present?
           errors += validate_choice(value, rules["choice"], name)
         end
@@ -65,26 +81,32 @@ module Chef::Validation
         BOOLEAN        = "boolean".freeze
         NUMERIC        = "numeric".freeze
 
-        def recipe_present?(node, recipe)
+        def recipe_present?(recipes, recipe)
           cookbook, name = recipe.split("::", 2)
           if name.blank?
             # Check for default recipe by both of it's names.
             expanded = "#{cookbook}::default"
-            node.recipe?(recipe) || node.recipe?(expanded)
+            recipes.include?(recipe) || recipes.include?(expanded)
           else
-            node.recipe?(recipe)
+            recipes.include?(recipe)
           end
         end
 
         def validate_choice(value, choices, name)
           errors = []
-          unless choices.include?(value)
-            errors << "Must be one of the following choices: #{choices.join(", ")}."
+          if value.is_a?(Array)
+            unless value.select { |v| !choices.include?(v) }.empty?
+              errors << "Must be any of the following choices: #{choices.join(", ")}."
+            end
+          else
+            unless choices.include?(value)
+              errors << "Must be one of the following choices: #{choices.join(", ")}."
+            end
           end
           errors
         end
 
-        def validate_required(required, value)
+        def validate_required(required, value, name)
           errors = []
           return errors if value.is_a?(TrueClass) || value.is_a?(FalseClass)
 
@@ -94,15 +116,14 @@ module Chef::Validation
 
           # Only required gets here
           if value.blank?
-            errors << "Required attribute but was not present."
+            errors << "Attribute #{name} is required but was not present."
           end
           errors
         end
 
         def validate_type(value, type, name)
           errors = []
-          state  = nil
-          case type.downcase
+          case type.strip.downcase
           when STRING
             state = :error unless value.is_a?(String)
           when ARRAY
@@ -122,6 +143,7 @@ module Chef::Validation
           if state == :error
             errors << "Must be of type '#{type}' but got: #{value.class}."
           end
+
           errors
         end
     end

--- a/lib/chef/validation/version.rb
+++ b/lib/chef/validation/version.rb
@@ -1,4 +1,4 @@
 class Chef; end;
 module Chef::Validation
-  VERSION = "0.2.1"
+  VERSION = "0.3.0"
 end

--- a/spec/shared/data.rb
+++ b/spec/shared/data.rb
@@ -1,0 +1,58 @@
+def node
+  {
+    'cookbook' => {
+      'fun' => {
+        'stuff' => 'value',
+        'stuff2' => [
+          'secret',
+          'production',
+        ],
+      },
+      'timeout' => 200,
+      'memory' => {
+        'min' => 1024,
+        'max' => 2048
+      },
+      'tags' => [
+        'production',
+        'secret'
+      ],
+      'works' => false,
+      'simba' => :foo,
+      'party' => {
+        'yes' => {
+          'party' => true,
+          'work'  => false,
+          'things' => {
+            'wooo' => {
+              'stuff' => true
+            }
+          }
+        },
+        'no' => {
+          'party' => false,
+          'work'  => true
+        }
+      },
+      'volumes' => [
+        {
+          'user' => 'ubuntu',
+          'device' => '/dev/sdm',
+          'mount' => '/data'
+        },
+        {
+          'mode' => '777',
+          'device' => '/dev/sdo',
+          'mount' => '/db'
+        }
+      ]
+    }
+  }
+end
+
+def recipes
+  [
+    'config',
+    'foo',
+  ]
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,27 @@
+require 'rspec'
+require 'chefspec'
+require 'chef/validation'
+
+# Get in data examples
+Dir["./spec/shared/**/*.rb"].each {|f| require f}
+
+RSpec.configure do |config|
+  # Prohibit using the should syntax
+  config.expect_with :rspec do |spec|
+    spec.syntax = :expect
+  end
+
+  # Focus groups
+  config.filter_run(focus: true)
+  config.run_all_when_everything_filtered = true
+
+  # Run specs in random order to surface order dependencies. If you find an
+  # order dependency and want to debug it, you can fix the order by providing
+  # the seed, which is printed after each run.
+  #     --seed 1234
+  config.order = 'random'
+
+  # ChefSpec configuration
+  config.log_level = :fatal
+end
+

--- a/spec/unit/chef/validation/hashext_spec.rb
+++ b/spec/unit/chef/validation/hashext_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe Chef::Validation::HashExt do
+  context '.dig' do
+    it 'can access a simple element' do
+      expect(described_class.dig(node, 'cookbook/timeout')).to eq(200)
+    end
+
+    it 'can access and return a nested structure' do
+      expect(described_class.dig(node, 'cookbook/party/yes')).to eq(node['cookbook']['party']['yes'])
+    end
+
+    it 'can access elements in an array' do
+      expect(described_class.dig(node, 'cookbook/volumes/1/device')).to eq('/dev/sdo')
+    end
+  end
+end

--- a/spec/unit/chef/validation/validator/validate_spec.rb
+++ b/spec/unit/chef/validation/validator/validate_spec.rb
@@ -1,0 +1,137 @@
+require 'spec_helper'
+
+describe Chef::Validation::Validator do
+  describe '.validate' do
+    context '#validate_type' do
+      it 'string' do
+        rules = {'type' => 'string'}
+        expect(described_class.validate(node, 'cookbook/fun/stuff', rules)).to be_empty
+        expect(described_class.validate(node, 'cookbook/tags', rules))
+            .to eq(["Must be of type 'string' but got: Array."])
+      end
+
+      it 'numeric' do
+        rules = {'type' => 'numeric'}
+        expect(described_class.validate(node, 'cookbook/timeout', rules)).to be_empty
+        expect(described_class.validate(node, 'cookbook/fun/stuff', rules))
+            .to eq(["Must be of type 'numeric' but got: String."])
+      end
+
+      it 'hash' do
+        rules = {'type' => 'hash'}
+        expect(described_class.validate(node, 'cookbook/memory', rules)).to be_empty
+        expect(described_class.validate(node, 'cookbook/fun/stuff', rules))
+            .to eq(["Must be of type 'hash' but got: String."])
+      end
+
+      it 'array' do
+        rules = {'type' => 'array'}
+        expect(described_class.validate(node, 'cookbook/tags', rules)).to be_empty
+        expect(described_class.validate(node, 'cookbook/fun/stuff', rules))
+            .to eq(["Must be of type 'array' but got: String."])
+      end
+
+      it 'boolean' do
+        rules = {'type' => 'boolean'}
+        expect(described_class.validate(node, 'cookbook/works', rules)).to be_empty
+        expect(described_class.validate(node, 'cookbook/fun/stuff', rules))
+            .to eq(["Must be of type 'boolean' but got: String."])
+      end
+
+      it 'symbol' do
+        rules = {'type' => 'symbol'}
+        expect(described_class.validate(node, 'cookbook/simba', rules)).to be_empty
+        expect(described_class.validate(node, 'cookbook/fun/stuff', rules))
+            .to eq(["Must be of type 'symbol' but got: String."])
+      end
+    end
+
+    context '#validate_choice' do
+      context 'string' do
+        it 'choice exists' do
+          rules = {
+            'type' => 'string',
+            'choice' => ['production', 'secret', 'value']
+          }
+          expect(described_class.validate(node, 'cookbook/fun/stuff', rules)).to be_empty
+        end
+
+        it 'choice does not exist' do
+          rules = {
+            'type' => 'string',
+            'choice' => ['production', 'public']
+          }
+          expect(described_class.validate(node, 'cookbook/fun/stuff', rules))
+              .to eq(["Must be one of the following choices: production, public."])
+        end
+      end
+
+      context 'array' do
+        it 'choices exist' do
+          rules = {
+            'type' => 'array',
+            'choice' => ['production', 'secret', 'value']
+          }
+          expect(described_class.validate(node, 'cookbook/fun/stuff2', rules)).to be_empty
+        end
+
+        it 'choices do not exist' do
+          rules = {
+            'type' => 'array',
+            'choice' => ['production', 'public']
+          }
+          expect(described_class.validate(node, 'cookbook/fun/stuff2', rules))
+              .to eq(["Must be any of the following choices: production, public."])
+        end
+      end
+    end
+
+    context '#validate_required' do
+      context 'is required' do
+        it 'value is string' do
+          rules = {'required' => 'required'}
+          expect(described_class.validate(node, 'cookbook/fun/stuff', rules)).to be_empty
+
+          expect(described_class.validate(node, 'cookbook/fun/stuff-gone', rules))
+              .to eq(["Attribute cookbook/fun/stuff-gone is required but was not present."])
+
+        end
+
+        it 'value is boolean' do
+          rules = {'required' => true}
+          expect(described_class.validate(node, 'cookbook/fun/stuff', rules)).to be_empty
+
+          expect(described_class.validate(node, 'cookbook/fun/stuff-gone', rules))
+              .to eq(["Attribute cookbook/fun/stuff-gone is required but was not present."])
+
+        end
+      end
+
+      context 'is optional' do
+        it 'value is string' do
+          rules = {'required' => 'optional'}
+          expect(described_class.validate(node, 'cookbook/fun/stuff', rules)).to be_empty
+          expect(described_class.validate(node, 'cookbook/fun/stuff-gone', rules)).to be_empty
+        end
+
+        it 'value is boolean' do
+          rules = {'required' => false}
+          expect(described_class.validate(node, 'cookbook/fun/stuff', rules)).to be_empty
+          expect(described_class.validate(node, 'cookbook/fun/stuff-gone', rules)).to be_empty
+        end
+      end
+    end
+
+    context '#recipe_present' do
+      it 'config is an available recipe' do
+        rules = {'type' => 'string', 'recipes' => ['config']}
+        expect(described_class.validate(node, 'cookbook/fun/stuff', rules, recipes)).to be_empty
+      end
+
+      it 'config2 is not an available recipe' do
+        rules = {'type' => 'string', 'recipes' => ['config2']}
+        expect(described_class.validate(node, 'cookbook/fun/stuff', rules, recipes)).to be_empty
+      end
+    end
+  end
+end

--- a/spec/unit/chef/validation/validator/validate_spec.rb
+++ b/spec/unit/chef/validation/validator/validate_spec.rb
@@ -70,7 +70,7 @@ describe Chef::Validation::Validator do
         it 'choices exist' do
           rules = {
             'type' => 'array',
-            'choice' => ['production', 'secret', 'value']
+            'choices' => ['production', 'secret', 'value']
           }
           expect(described_class.validate(node, 'cookbook/fun/stuff2', rules)).to be_empty
         end
@@ -78,7 +78,7 @@ describe Chef::Validation::Validator do
         it 'choices do not exist' do
           rules = {
             'type' => 'array',
-            'choice' => ['production', 'public']
+            'choices' => ['production', 'public']
           }
           expect(described_class.validate(node, 'cookbook/fun/stuff2', rules))
               .to eq(["Must be any of the following choices: production, public."])

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+describe 'validation::default' do
+  let(:chef_run) { ChefSpec::SoloRunner.converge(described_recipe) }
+
+  it 'installs the chef gem' do
+    expect(chef_run).to install_chef_gem('chef-validation')
+      .with(version: Chef::Validation::VERSION)
+  end
+end


### PR DESCRIPTION
This does change a few things internally.

Validator now does not attempt to access Chef objects directly and instead expects hashes to be sent to it. One of the annoying pieces here is around .
This was done both to make testing simpler and to make it possible to use the gem _outside_ the Chef context, such as I have the data structure already from Chef and just want to validate it in Ruby

This PR pretty much depends on #3, #4 and #5 and will need a rebase when/if those are merged.

I'm pretty new to rspec so I'm open to suggestions on how to improve this :)
